### PR TITLE
Add missing server id

### DIFF
--- a/settings.xml
+++ b/settings.xml
@@ -4,6 +4,7 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <servers>
         <server>
+            <id>snapshots</id>
             <username>${env.BINTRAY_USER}</username>
             <password>${env.BINTRAY_KEY}</password>
         </server>


### PR DESCRIPTION
The id is needed to correlate the properties in the `settings.xml` with
the distribution repository in the POMs. The id `snapshots` is used in
the connector4java's POM.
